### PR TITLE
fix: avoid redundant repo downloads and dnf cache clears

### DIFF
--- a/tasks/repo/repo.Debian.yml
+++ b/tasks/repo/repo.Debian.yml
@@ -23,7 +23,6 @@
   get_url:
     url: "https://repo.zabbix.com/zabbix/{{ zabbix_version }}/release/{{ ansible_facts['distribution'] | lower }}/pool/main/z/zabbix-release/{{ ansible_zabbix_repo }}"
     dest: "/tmp/{{ ansible_zabbix_repo }}"
-    force: yes
   tags:
     - repo
 

--- a/tasks/repo/repo.RedHat.yml
+++ b/tasks/repo/repo.RedHat.yml
@@ -4,6 +4,7 @@
     name: "https://repo.zabbix.com/zabbix/{{ zabbix_version }}/release/rhel/{{ ansible_distribution_major_version }}/{{ ansible_architecture }}/zabbix-release-latest.el{{ ansible_distribution_major_version }}.noarch.rpm"
     state: present
     disable_gpg_check: false
+  register: zabbix_repo_install
   tags:
     - repo
     - agent.install
@@ -13,6 +14,7 @@
 - name: Clean dnf cache after repo install
   ansible.builtin.command: dnf clean all
   changed_when: false
+  when: zabbix_repo_install.changed
   tags:
     - repo
     - agent.install


### PR DESCRIPTION
## What
Remove unnecessary work from the Zabbix repo install tasks on both Debian and RedHat.

## Why
`force: yes` on `get_url` caused the Zabbix release `.deb` to be re-downloaded on every Ansible run. On RedHat, `dnf clean all` ran unconditionally after every play even when the repo RPM was already present.

## Changes
- `tasks/repo/repo.Debian.yml`: remove `force: yes` from `get_url` — file is now skipped if already present and unchanged
- `tasks/repo/repo.RedHat.yml`: register result of dnf repo install; gate `dnf clean all` on `when: zabbix_repo_install.changed`

🤖 Generated with [Claude Code](https://claude.ai/code)